### PR TITLE
Use updatePullRequest mutation to update PRs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
         "singleQuote": true,
         "printWidth": 120
       }
-    ]
+    ],
+    "no-underscore-dangle": ["error", { "allow": ["__typename"] }]
   },
   "plugins": [
     "prettier"

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -5,6 +5,7 @@ crossReferences: timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) 
   nodes {
     ... on CrossReferencedEvent {
       source {
+        __typename
         ... on Issue {
           id
           body
@@ -42,7 +43,18 @@ mutation updateIssue($id: ID!, $body: String) {
 }
 `.trim();
 
+const UPDATE_PULL_REQUEST_BODY = `
+mutation updatePullRequest($id: ID!, $body: String) {
+  updatePullRequest(input: { pullRequestId: $id, body: $body }) {
+    pullRequest {
+      id
+    }
+  }
+}
+`.trim();
+
 module.exports = {
   GET_CROSSREFERENCED_ITEMS,
-  UPDATE_ISSUE_BODY
+  UPDATE_ISSUE_BODY,
+  UPDATE_PULL_REQUEST_BODY
 };

--- a/src/sync-task-issues.js
+++ b/src/sync-task-issues.js
@@ -60,8 +60,12 @@ async function run() {
       // if the body changes from checking boxes, push the changes back to GitHub
       const updatedBody = reference.body.replace(regex, `$1- [${replace}]$2`);
       if (updatedBody !== reference.body) {
-        core.info(`updating ${reference.id}`);
-        await api(queries.UPDATE_ISSUE_BODY, { id: reference.id, body: updatedBody });
+        core.info(`updating ${reference.__typename} ${reference.id}`);
+        if (reference.__typename === 'Issue') {
+          await api(queries.UPDATE_ISSUE_BODY, { id: reference.id, body: updatedBody });
+        } else if (reference.__typename === 'PullRequest') {
+          await api(queries.UPDATE_PULL_REQUEST_BODY, { id: reference.id, body: updatedBody });
+        }
       }
     });
   } catch (error) {

--- a/test/sync-task-issues.test.js
+++ b/test/sync-task-issues.test.js
@@ -104,12 +104,14 @@ describe('sync-task-issues', () => {
       response.node.crossReferences.nodes = [
         {
           source: {
+            __typename: 'Issue',
             id: 'source-1',
             body: originalBody
           }
         },
         {
           source: {
+            __typename: 'PullRequest',
             id: 'source-2',
             body: originalBody
           }
@@ -128,7 +130,7 @@ describe('sync-task-issues', () => {
         { id: response.node.crossReferences.nodes[0].source.id, body: expectedBody }
       ]);
       expect(api.getCall(2).args).toEqual([
-        queries.UPDATE_ISSUE_BODY,
+        queries.UPDATE_PULL_REQUEST_BODY,
         { id: response.node.crossReferences.nodes[1].source.id, body: expectedBody }
       ]);
 
@@ -162,12 +164,14 @@ describe('sync-task-issues', () => {
       response.node.crossReferences.nodes = [
         {
           source: {
+            __typename: 'Issue',
             id: 'source-1',
             body: originalBody
           }
         },
         {
           source: {
+            __typename: 'PullRequest',
             id: 'source-2',
             body: originalBody
           }
@@ -186,7 +190,7 @@ describe('sync-task-issues', () => {
         { id: response.node.crossReferences.nodes[0].source.id, body: expectedBody }
       ]);
       expect(api.getCall(2).args).toEqual([
-        queries.UPDATE_ISSUE_BODY,
+        queries.UPDATE_PULL_REQUEST_BODY,
         { id: response.node.crossReferences.nodes[1].source.id, body: expectedBody }
       ]);
 
@@ -222,12 +226,14 @@ describe('sync-task-issues', () => {
       response.node.crossReferences.nodes = [
         {
           source: {
+            __typename: 'Issue',
             id: 'source-1',
             body: originalBody
           }
         },
         {
           source: {
+            __typename: 'PullRequest',
             id: 'source-2',
             body: originalBody
           }
@@ -246,7 +252,7 @@ describe('sync-task-issues', () => {
         { id: response.node.crossReferences.nodes[0].source.id, body: expectedBody }
       ]);
       expect(api.getCall(2).args).toEqual([
-        queries.UPDATE_ISSUE_BODY,
+        queries.UPDATE_PULL_REQUEST_BODY,
         { id: response.node.crossReferences.nodes[1].source.id, body: expectedBody }
       ]);
 
@@ -281,12 +287,14 @@ describe('sync-task-issues', () => {
       response.node.crossReferences.nodes = [
         {
           source: {
+            __typename: 'Issue',
             id: 'source-1',
             body: originalBody
           }
         },
         {
           source: {
+            __typename: 'PullRequest',
             id: 'source-2',
             body: originalBody
           }
@@ -305,7 +313,7 @@ describe('sync-task-issues', () => {
         { id: response.node.crossReferences.nodes[0].source.id, body: expectedBody }
       ]);
       expect(api.getCall(2).args).toEqual([
-        queries.UPDATE_ISSUE_BODY,
+        queries.UPDATE_PULL_REQUEST_BODY,
         { id: response.node.crossReferences.nodes[1].source.id, body: expectedBody }
       ]);
 
@@ -372,12 +380,14 @@ describe('sync-task-issues', () => {
       response.node.crossReferences.nodes = [
         {
           source: {
+            __typename: 'Issue',
             id: 'source-1',
             body: originalBody
           }
         },
         {
           source: {
+            __typename: 'PullRequest',
             id: 'source-2',
             body: originalBody
           }
@@ -399,7 +409,7 @@ describe('sync-task-issues', () => {
         { id: response.node.crossReferences.nodes[0].source.id, body: expectedBody }
       ]);
       expect(api.getCall(2).args).toEqual([
-        queries.UPDATE_ISSUE_BODY,
+        queries.UPDATE_PULL_REQUEST_BODY,
         { id: response.node.crossReferences.nodes[1].source.id, body: expectedBody }
       ]);
 
@@ -433,12 +443,14 @@ describe('sync-task-issues', () => {
       response.node.crossReferences.nodes = [
         {
           source: {
+            __typename: 'Issue',
             id: 'source-1',
             body: originalBody
           }
         },
         {
           source: {
+            __typename: 'PullRequest',
             id: 'source-2',
             body: originalBody
           }
@@ -460,7 +472,7 @@ describe('sync-task-issues', () => {
         { id: response.node.crossReferences.nodes[0].source.id, body: expectedBody }
       ]);
       expect(api.getCall(2).args).toEqual([
-        queries.UPDATE_ISSUE_BODY,
+        queries.UPDATE_PULL_REQUEST_BODY,
         { id: response.node.crossReferences.nodes[1].source.id, body: expectedBody }
       ]);
 
@@ -496,12 +508,14 @@ describe('sync-task-issues', () => {
       response.node.crossReferences.nodes = [
         {
           source: {
+            __typename: 'Issue',
             id: 'source-1',
             body: originalBody
           }
         },
         {
           source: {
+            __typename: 'PullRequest',
             id: 'source-2',
             body: originalBody
           }
@@ -523,7 +537,7 @@ describe('sync-task-issues', () => {
         { id: response.node.crossReferences.nodes[0].source.id, body: expectedBody }
       ]);
       expect(api.getCall(2).args).toEqual([
-        queries.UPDATE_ISSUE_BODY,
+        queries.UPDATE_PULL_REQUEST_BODY,
         { id: response.node.crossReferences.nodes[1].source.id, body: expectedBody }
       ]);
 
@@ -558,12 +572,14 @@ describe('sync-task-issues', () => {
       response.node.crossReferences.nodes = [
         {
           source: {
+            __typename: 'Issue',
             id: 'source-1',
             body: originalBody
           }
         },
         {
           source: {
+            __typename: 'PullRequest',
             id: 'source-2',
             body: originalBody
           }
@@ -585,7 +601,7 @@ describe('sync-task-issues', () => {
         { id: response.node.crossReferences.nodes[0].source.id, body: expectedBody }
       ]);
       expect(api.getCall(2).args).toEqual([
-        queries.UPDATE_ISSUE_BODY,
+        queries.UPDATE_PULL_REQUEST_BODY,
         { id: response.node.crossReferences.nodes[1].source.id, body: expectedBody }
       ]);
 


### PR DESCRIPTION
This fixes an issue when a pull request references the closed issue/PR.  In that scenario, the code was still calling the `updateIssue` mutation, which was returning an error because the passed in node id does not specify an issue.