### PR TITLE
Update README with better usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,20 @@ Create a YAML file in the `.github/workflows` folder of your repository with the
 ```yml
 name: Cross off linked issues
 on:
+  # the closed event type causes unchecked checkbox references to be checked / marked complete
+  # the reopened event type causes checked checkbox references to be unchecked / marked incomplete
   issues:
-    types: [closed]
+    types: [closed, reopened]
+
+  # the action works on pull request events as well
+  pull_requests:
+    types: [closed, reopened]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Cross of any linked issues
+      - name: Cross of any linked issue and PR references
         uses: jonabc/sync-task-issues@v1
 ```
 


### PR DESCRIPTION
Closes https://github.com/jonabc/sync-task-issues/issues/12

Updates the usage section in the readme to add 
- `reopened` event type, needed for the action to mark checked references as incomplete
- `pull_requests` event, showing compatibility with that event as well as `issues`
- comments describing the events and event types