### PR TITLE
Add outputs to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,22 @@ jobs:
         uses: jonabc/sync-task-issues@v1
 ```
 
-### State input
-
-A `state` input is available to explicitly configure whether to mark references as complete or incomplete when the action is triggered.  Available values are `complete` and `incomplete`.
-
 ## Required permissions
 
 The default ${{ secrets.GITHUB_TOKEN }} token can be used only when both the closed issues or PRs and their references are in the same repo.
 
 For cross-repo references, a personal access token with `repo` access is needed from a user account that can `write` to the all repositories containing references.
+
+### Inputs
+
+- `state`: explicitly configure whether to mark references as complete or incomplete when the action is triggered
+   - accepts either `complete` and `incomplete`
+
+### Outputs
+
+- `mark_references_as`: Either `complete` or `incomplete`, showing how references were marked by the action
+- `references`: The list of objects obtained from the GitHub API that referenced the current issue or PR
+   - output using `JSON.stringify`, ex. `[{ ... reference 1 }, { ... reference 2 }]`
+   - see [graphql.js#fields](./src/graphql.js) for which data fields are fetched from the API
+- `updated`: A list of `${type}:${id}` strings that identify which objects from `references` were updated
+   - output using `JSON.stringify`, ex. `["Issue:1", "PullRequest:2"]`

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,13 @@ inputs:
   state:
     description: '(Optional) An explicit state to mark references - complete or incomplete'
     required: false
+outputs:
+  mark_references_as:
+    description: Either `complete` or `incomplete`, showing how references were marked by the action
+  references:
+    description: The list of objects obtained from the GitHub API that referenced the current issue or PR
+  updated:
+    description: A list of `${type}:${id}` strings that identify which objects from "references" were updated
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/test/sync-task-issues.test.js
+++ b/test/sync-task-issues.test.js
@@ -23,6 +23,7 @@ describe('sync-task-issues', () => {
 
     sinon.stub(core, 'setFailed');
     sinon.stub(core, 'info');
+    sinon.stub(core, 'setOutput');
 
     // eslint-disable-next-line global-require
     response = JSON.parse(
@@ -135,6 +136,19 @@ describe('sync-task-issues', () => {
       ]);
 
       expect(core.setFailed.callCount).toEqual(0);
+
+      expect(core.setOutput.callCount).toEqual(3);
+      expect(core.setOutput.getCall(0).args).toEqual(['mark_references_as', 'complete']);
+      expect(core.setOutput.getCall(1).args).toEqual([
+        'references',
+        JSON.stringify(response.node.crossReferences.nodes)
+      ]);
+      expect(core.setOutput.getCall(2).args).toEqual([
+        'updated',
+        JSON.stringify(
+          response.node.crossReferences.nodes.map(({ source: { __typename, id } }) => `${__typename}:${id}`)
+        )
+      ]);
     });
 
     it('marks matching complete checkbox list references as incomplete for reopened event', async () => {
@@ -195,6 +209,19 @@ describe('sync-task-issues', () => {
       ]);
 
       expect(core.setFailed.callCount).toEqual(0);
+
+      expect(core.setOutput.callCount).toEqual(3);
+      expect(core.setOutput.getCall(0).args).toEqual(['mark_references_as', 'incomplete']);
+      expect(core.setOutput.getCall(1).args).toEqual([
+        'references',
+        JSON.stringify(response.node.crossReferences.nodes)
+      ]);
+      expect(core.setOutput.getCall(2).args).toEqual([
+        'updated',
+        JSON.stringify(
+          response.node.crossReferences.nodes.map(({ source: { __typename, id } }) => `${__typename}:${id}`)
+        )
+      ]);
     });
 
     it('marks matching incomplete checkbox list references as complete for complete state input', async () => {
@@ -414,6 +441,19 @@ describe('sync-task-issues', () => {
       ]);
 
       expect(core.setFailed.callCount).toEqual(0);
+
+      expect(core.setOutput.callCount).toEqual(3);
+      expect(core.setOutput.getCall(0).args).toEqual(['mark_references_as', 'complete']);
+      expect(core.setOutput.getCall(1).args).toEqual([
+        'references',
+        JSON.stringify(response.node.crossReferences.nodes)
+      ]);
+      expect(core.setOutput.getCall(2).args).toEqual([
+        'updated',
+        JSON.stringify(
+          response.node.crossReferences.nodes.map(({ source: { __typename, id } }) => `${__typename}:${id}`)
+        )
+      ]);
     });
 
     it('marks matching complete checkbox list references as incomplete for reopened event', async () => {
@@ -477,6 +517,19 @@ describe('sync-task-issues', () => {
       ]);
 
       expect(core.setFailed.callCount).toEqual(0);
+
+      expect(core.setOutput.callCount).toEqual(3);
+      expect(core.setOutput.getCall(0).args).toEqual(['mark_references_as', 'incomplete']);
+      expect(core.setOutput.getCall(1).args).toEqual([
+        'references',
+        JSON.stringify(response.node.crossReferences.nodes)
+      ]);
+      expect(core.setOutput.getCall(2).args).toEqual([
+        'updated',
+        JSON.stringify(
+          response.node.crossReferences.nodes.map(({ source: { __typename, id } }) => `${__typename}:${id}`)
+        )
+      ]);
     });
 
     it('marks matching incomplete checkbox list references as complete for complete state input', async () => {


### PR DESCRIPTION
closes https://github.com/jonabc/sync-task-issues/issues/20

Adds the following outputs to the action, for use in followup actions
```yml
outputs:
  mark_references_as:
    description: Either `complete` or `incomplete`, showing how references were marked by the action
  references:
    description: The list of objects obtained from the GitHub API that referenced the current issue or PR
  updated:
    description: A list of `${type}:${id}` strings that identify which objects from "references" were updated
```