### PR TITLE
Add github_token input to readme sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Cross off any linked issue and PR references
         uses: jonabc/sync-task-issues@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Required permissions

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For cross-repo references, a personal access token with `repo` access is needed 
 
 ### Inputs
 
+- `github_token`: the token to use for authenticated GitHub API requests
 - `state`: explicitly configure whether to mark references as complete or incomplete when the action is triggered
    - accepts either `complete` and `incomplete`
 


### PR DESCRIPTION
closes https://github.com/jonabc/sync-task-issues/issues/24

As mentioned in the linked issue, the sample in the README doesn't give any guidance on how to set an auth token in the action.  Quick change here to add that in.